### PR TITLE
Added `watchOptions` to fix automatic rebuild on Vagrant

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,7 +3,11 @@ var WebpackDevServer = require('webpack-dev-server');
 var config = require('./webpack.config');
 
 new WebpackDevServer(webpack(config), {
-    publicPath: config.output.publicPath
+    publicPath: config.output.publicPath,
+    watchOptions: {
+      aggregateTimeout: 300,
+      poll: 1000
+    }
   })
   .listen(3000, '0.0.0.0', function (err, result) {
     if (err) {


### PR DESCRIPTION
Apparently the usual watching mechanism doesn't work on Linux/Vagrant
when files are changed on the host machine. This fixes it.
