### PR TITLE
Added instruction to cd into the cloned directory before removing remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Clone the boilerplate and create your own git repo.
 
 ```
 git clone git@github.com:lighthouse-labs/react-simple-boilerplate.git
+cd react-simple-boilerplate
 git remote rm origin
 git remote add origin [YOUR NEW REPOSITORY]
 # Manually update your package.json file


### PR DESCRIPTION
Added instruction to `cd` into the cloned directory before removing remotes, was tripping up some students.