### PR TITLE
Update dependencies, migrate to webpack v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,23 +29,23 @@
     "node": ">=6.0.0"
   },
   "devDependencies": {
-    "babel-core": "6.10.4",
-    "babel-loader": "6.0.1",
-    "babel-preset-es2015": "6.9.0",
-    "babel-preset-react": "6.11.1",
-    "babel-preset-stage-0": "6.5.0",
-    "css-loader": "0.23.1",
-    "eslint": "2.7.0",
-    "eslint-plugin-react": "5.2.2",
-    "node-sass": "3.8.0",
-    "sass-loader": "4.0.0",
-    "sockjs-client": "^1.1.1",
+    "babel-core": "6.23.1",
+    "babel-loader": "6.3.1",
+    "babel-preset-es2015": "6.22.0",
+    "babel-preset-react": "6.23.0",
+    "babel-preset-stage-0": "6.22.0",
+    "css-loader": "0.26.1",
+    "eslint": "3.15.0",
+    "eslint-plugin-react": "6.9.0",
+    "node-sass": "4.5.0",
+    "sass-loader": "6.0.0",
+    "sockjs-client": "^1.1.2",
     "style-loader": "0.13.1",
-    "webpack": "1.13.1",
-    "webpack-dev-server": "1.14.1"
+    "webpack": "2.2.1",
+    "webpack-dev-server": "2.3.0"
   },
   "dependencies": {
-    "react": "15.2.1",
-    "react-dom": "15.2.1"
+    "react": "15.4.2",
+    "react-dom": "15.4.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,16 +13,20 @@ module.exports = {
     publicPath: '/build/'
   },
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.jsx?$/,
-        loaders: ['babel'],
+        loader: 'babel-loader',
         include: path.join(__dirname, 'src')
       },
       {
         test: /\.scss$/,
-        loaders: ["style", "css", "sass"]
+        use: [
+          'style-loader',
+          'css-loader',
+          'sass-loader'
+        ]
       }
     ]
   }
-}
+};


### PR DESCRIPTION
All outdated dependencies have been updated to their latest versions. webpack has changed their configuration API for version 2, so the **webpack.config.js** file has been updated to reflect the new approach based on their "Migrating from v1 to v2" page.

https://webpack.js.org/guides/migrating/