### PR TITLE
[High CPU/slowdowns issue] webpack watch should ignore node_modules

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,8 @@ new WebpackDevServer(webpack(config), {
     publicPath: config.output.publicPath,
     watchOptions: {
       aggregateTimeout: 300,
-      poll: 1000
+      poll: 1000,
+      ignored: /node_modules/
     }
   })
   .listen(3000, '0.0.0.0', function (err, result) {


### PR DESCRIPTION
This is quite likely to be the cause of the common high CPU
usage and excessive slowdown experienced by students using
this boilerplate.

This only happens because we turn on polling, but we turn
on polling because we have to (for Vagrant).

See https://github.com/webpack/watchpack/pull/23