### PR TITLE
Update lint script to scan JSX files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Simple and lightweight Boilerplate for ReactJS projects",
   "scripts": {
-    "lint": "eslint src",
+    "lint": "eslint --ext .jsx,.js src",
     "start": "node server.js"
   },
   "repository": {


### PR DESCRIPTION
By default, `eslint` only scans js files, so running `eslint src` doesn't actually report anything since all the files there are `.jsx`.

This updates the script to include `.jsx` files in the scan performed by `eslint`

See http://eslint.org/docs/user-guide/configuring#specifying-file-extensions-to-lint for info