### PR TITLE
Upgrade to webpack 4

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "stage-0", "react"]
+  "presets": ["@babel/env", "@babel/react"]
 }

--- a/package.json
+++ b/package.json
@@ -29,20 +29,19 @@
     "node": ">=6.0.0"
   },
   "devDependencies": {
-    "babel-core": "6.23.1",
-    "babel-loader": "6.3.1",
-    "babel-preset-es2015": "6.22.0",
-    "babel-preset-react": "6.23.0",
-    "babel-preset-stage-0": "6.22.0",
+    "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.1.5",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.4",
     "css-loader": "0.26.1",
     "eslint": "3.15.0",
     "eslint-plugin-react": "6.9.0",
     "node-sass": "4.5.0",
-    "sass-loader": "6.0.0",
+    "sass-loader": "^7.1.0",
     "sockjs-client": "^1.1.2",
     "style-loader": "0.13.1",
-    "webpack": "2.2.1",
-    "webpack-dev-server": "2.3.0"
+    "webpack": "^4.25.1",
+    "webpack-dev-server": "^3.1.10"
   },
   "dependencies": {
     "react": "15.4.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,10 @@
-var path = require('path');
-var webpack = require('webpack');
+const path = require('path');
+const webpack = require('webpack');
+const NODE_ENV = process.env.NODE_ENV || 'development';
 
 module.exports = {
   devtool: 'eval',
+  mode: NODE_ENV,
   entry: [
     'webpack-dev-server/client?http://localhost:3000',
     './src/index.jsx'


### PR DESCRIPTION
Upgrading the base project to use `webpack@^4.0` 

Also using latest babel version (7.0) and `@babel/preset-env` which replaces `babel-preset-es2015`

Tested on the vagrant machine that the students use.